### PR TITLE
README.md - complete path to tslint.json for „extends“

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ npm install --save-dev @egodigital/tsconfig
 
 ```json
 {
-    "extends": "@egodigital/tsconfig",
+    "extends": "@egodigital/tsconfig/tslint.json",
     "rules": {
         "semicolon": [
             true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@egodigital/tsconfig",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"description": "Shared TypeScript and tslint config files for e.GO projects.",
 	"license": "MIT",
 	"repository": "egodigital/tsconfig",


### PR DESCRIPTION
According to my tests with `--print-config` option of tslint the linter config ist not correctly extended unless full path to tslint.json is given.
